### PR TITLE
Cambiado el archivo de routes :id significa opcional, por {id} obligatorio

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -28,70 +28,70 @@ POST       /conductor                 controllers.DriverController.create()
 #Obtener todos los usuarios
 GET        /usuarios                 controllers.UserController.read()
 #Obtener los datos de un usuario
-GET        /usuarios/{id}             controllers.UserController.read()
+GET        /usuarios/{id}            controllers.UserController.read()
 #Registrar un nuevo usuario
 POST       /usuarios                 controllers.UserController.create()
 #Modificar datos de un usuario
 PUT	/usuarios/{id}                   controllers.UserController.modify()
 #Obtener reservas de un usuario
-GET        /usuarios/:id/reservas
+GET        /usuarios/{id}/reservas
 #Crear una reserva
-POST        /usuarios/:id/reservas
+POST        /usuarios/{id}/reservas
 #Modificar una reserva
-PUT        /usuarios/:id/reservas/:id2
+PUT        /usuarios/{id}/reservas/{id2}
 #Eliminar una reserva
-DELETE        /usuarios/:id/reservas/:id2
+DELETE        /usuarios/{id}/reservas/{id2}
 
 
 ################################################################   MOBIBUSES  ############################################
 #Obtener todos los mobibuses del sistema
 GET        /mobibuses
 #Obtener los datos de un mobibus
-GET        /mobibuses/:id
+GET        /mobibuses/{id}
 #Registrar un nuevo mobibus
 POST        /mobibuses
 #Modificar datos de un mobibus
-PUT        /mobibuses/:id
+PUT        /mobibuses/{id}
 #Enviar los datos del mobibus (GPS, hora�)
-POST        /mobibuses/:id/datos
+POST        /mobibuses/{id}/datos
 #Obtener los datos registrados del mobibus (a trav�s del path param se podr�a indicar si traer s�lo el �ltimo dato, los n �ltimos datos, o la hora espec�fica de la que se quieren conocer los datos)  ** pueden ser mas rutas**
 
 
 #Registrar una revisi�n tecnomec�nica
-POST        /mobibuses/:id/revisiones
+POST        /mobibuses/{id}/revisiones
 #Obtener las revisiones tecnomec�nicas del veh�culo
-GET        /mobibuses/:id/revisiones
+GET        /mobibuses/{id}/revisiones
 #Registrar el inicio de un trayecto o ruta (con la hora, informaci�n del conductor y Ruta esperada)
-POST        /mobibuses/:id/trayectos
+POST        /mobibuses/{id}/trayectos
 #Modificar el registro para poner la hora final del trayecto
-PUT        /mobibuses/:id/trayectos/:id2
+PUT        /mobibuses/{id}/trayectos/{id2}
 #Obtener los trayectos de un tranv�a (Para obtener tiempos de conductores y percances
-GET        /mobibuses/:id/trayectos/
+GET        /mobibuses/{id}/trayectos/
 
 
 #####################################################################  TRANVIAS  #######################
 #Obtener todos los tranvias del sistema
 GET        /tranvias
 #Obtener los datos de un tranvia
-GET        /tranvias/:id
+GET        /tranvias/{id}
 #Registrar un nuevo tranvias
 POST        /tranvias
 #Modificar datos de un tranvias
-PUT        /tranvias/:id
+PUT        /tranvias/{id}
 #Enviar los datos del tranvias (GPS, hora�)
-POST        /tranvias/:id/datos
+POST        /tranvias/{id}/datos
 #Obtener los datos registrados del tranvias (a trav�s del path param se podr�a indicar si traer s�lo el �ltimo dato, los n �ltimos datos, o la hora espec�fica de la que se quieren conocer los datos)     ** pueden ser mas rutas**
 
 #Registrar una revisi�n tecnomec�nica
-POST        /tranvias/:id/revisiones
+POST        /tranvias/{id}/revisiones
 #Obtener las revisiones tecnomec�nicas del veh�culo
-GET        /tranvias/:id/revisiones
+GET        /tranvias/{id}/revisiones
 #Registrar el inicio de un trayecto o ruta (con la hora, informaci�n del conductor y Ruta esperada)
-POST        /tranvias/:id/trayectos
+POST        /tranvias/{id}/trayectos
 #Modificar el registro para poner la hora final del trayecto
-PUT        /tranvias/:id/trayectos/:id2
+PUT        /tranvias/{id}/trayectos/{id2}
 #Obtener los trayectos de un tranv�a (Para obtener tiempos de conductores y percances
-GET        /tranvias/:id/trayectos/
+GET        /tranvias/{id}/trayectos/
 
 
 
@@ -99,25 +99,25 @@ GET        /tranvias/:id/trayectos/
 #Obtener todos los vcubs del sistema
 GET        /vcubs
 #Obtener los datos de un vcubs
-GET        /vcubs/:id
+GET        /vcubs/{id}
 #Registrar un nuevo vcubs
 POST        /vcubs
 #Modificar datos de un vcubs
-PUT        /vcubs/:id
+PUT        /vcubs/{id}
 #Enviar los datos del vcubs (GPS, hora�)
 GET        /vcubs
 #Obtener los datos registrados del vcubs (a trav�s del path param se podr�a indicar si traer s�lo el �ltimo dato, los n �ltimos datos, o la hora espec�fica de la que se quieren conocer los datos)
 
 #Registrar una revisi�n tecnomec�nica
-POST        /vcubs/:id/revisiones
+POST        /vcubs/{id}/revisiones
 #Obtener las revisiones tecnomec�nicas del veh�culo
-GET        /vcubs/:id/revisiones
+GET        /vcubs/{id}/revisiones
 #Registrar el inicio de un trayecto o ruta (con la hora, informaci�n del conductor y Ruta esperada)
-POST        /vcubs/:id/trayectos
+POST        /vcubs/{id}/trayectos
 #Modificar el registro para poner la hora final del trayecto
-PUT        /vcubs/:id/trayectos/:id2
+PUT        /vcubs/{id}/trayectos/{id2}
 #Obtener los trayectos de un tranv�a (Para obtener tiempos de conductores y percances
-GET        /vcubs/:id/trayectos/
+GET        /vcubs/{id}/trayectos/
 
 
 
@@ -130,17 +130,17 @@ POST        /trayectos
 #Obtener todas las estaciones del sistema
 GET     /estaciones
 #Obtener los datos de una estaci�n
-GET     /estaciones/:id
+GET     /estaciones/{id}
 #Registrar una nueva estaci�n
 POST     /estaciones
 #Modificar datos de una estaci�n
-PUT     /estaciones/:id
+PUT     /estaciones/{id}
 #Obtener las bicicletas que se encuentran en una estaci�n
-GET     /estaciones/:id/bicicletas
+GET     /estaciones/{id}/bicicletas
 #Prestar una bicicleta en una estaci�n
-DELETE     /estaciones/:id/bicicletas/:id2
+DELETE     /estaciones/{id}/bicicletas/{id2}
 #Entregar una bicicleta en una estaci�n
-POST     /estaciones/:id/bicicletas
+POST     /estaciones/{id}/bicicletas
 
 
 


### PR DESCRIPTION
EL archivo de routes tenia los parámetros establecidos como :id e :id2 lo que puede causar problemas, puesto que quiere decir que estos no son necesarios y son opcionales en las que terminan con estos, no generaria ningún problema, pero las que son de la forma /:id/../:id2 pueden generarnos problemas, por eso las cambie a la forma {id} que establece entonces que estos deben ser oblifatorios.